### PR TITLE
Replace yourtempo.co links with archive.is URL

### DIFF
--- a/_data/tools.yml
+++ b/_data/tools.yml
@@ -84,17 +84,17 @@ tools:
       they offer more freedom and are way more affordable.
     el: ''
   img: "/uploads/webflow-logo.png"
-- name: Tempo
-  url: https://archive.is/4P3Qb
-  desc:
-    en: "Tempo is a (now free) macOS/iOS Gmail client. It creates a workspace that
-      won't get filled with new emails automatically; you have to manually add them.
-      Perfect for those overwhelmed by too many emails. \n\nDisclaimer: I used to
-      do customer support for Tempo. The app is no longer maintained but can be used
-      indefinitely."
-    el: "\n"
-  img: "/uploads/tempo-logo.png"
-  image: ''
+# - name: Tempo
+#   url: https://archive.is/4P3Qb
+#   desc:
+#     en: "Tempo is a (now free) macOS/iOS Gmail client. It creates a workspace that
+#       won't get filled with new emails automatically; you have to manually add them.
+#       Perfect for those overwhelmed by too many emails. \n\nDisclaimer: I used to
+#       do customer support for Tempo. The app is no longer maintained but can be used
+#       indefinitely."
+#     el: "\n"
+#   img: "/uploads/tempo-logo.png"
+#   image: ''
 # - name: Tweek
 #   url: https://tweek.so
 #   desc:

--- a/_data/tools.yml
+++ b/_data/tools.yml
@@ -85,7 +85,7 @@ tools:
     el: ''
   img: "/uploads/webflow-logo.png"
 - name: Tempo
-  url: https://www.yourtempo.co
+  url: https://archive.is/4P3Qb
   desc:
     en: "Tempo is a (now free) macOS/iOS Gmail client. It creates a workspace that
       won't get filled with new emails automatically; you have to manually add them.

--- a/_layouts/home.liquid
+++ b/_layouts/home.liquid
@@ -75,7 +75,7 @@ layout: default
     <div class="ph3-ns br4 pv2-ns bg-faint-ns inline-flex flex items-center justify-center flex-wrap gap2 f5">
       Previously at <a href="/{{page.lang}}/shopflix" class="flex items-center link nowrap"><img src="/assets/logo-shopflix.svg" class="mr2 dib w2" alt="" width="32" height="32">Shopflix</a>
       {% comment %} Previously at <a href="https://www.thesmilinghippo.com/" class="flex items-center link" target="_blank"><img src="/assets/logo-tsh.svg" class="mr2 dib w1 w2-ns h-auto" alt="" width="32" height="32">The Smiling Hippo</a>  {% endcomment %}
-      <span class="tertiary">and</span> <a href="https://www.yourtempo.co/" class="flex items-center link nowrap" target="_blank"><img src="/assets/logo-tempo.png" class="mr2 dib w2 h-auto" alt="" width="32" height="32">Tempo</a>
+      <span class="tertiary">and</span> <a href="https://archive.is/4P3Qb" class="flex items-center link nowrap" target="_blank"><img src="/assets/logo-tempo.png" class="mr2 dib w2 h-auto" alt="" width="32" height="32">Tempo</a>
     </div>
   </section>
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: only updates external URLs and comments in static site data/templates; no logic changes or data handling.
> 
> **Overview**
> Updates the site’s Tempo references to avoid linking to `yourtempo.co`.
> 
> The homepage “Previously at” Tempo link now points to `https://archive.is/4P3Qb`, and the `Tempo` entry in `_data/tools.yml` is commented out while also updating its stored URL to the same archive link.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c0d8166c16b6111c6822c537d7d2f625deaefb61. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->