### PR TITLE
Add unified notification inbox to /ideas

### DIFF
--- a/ideas.md
+++ b/ideas.md
@@ -70,6 +70,10 @@ ideas:
     emoji: "⏰"
     description: |
       Where you can create a multi step process with timed steps. E.g. "getting ready to go to the office" would have tasks like `make coffee - 8 min`, `drink coffee - 10 min`, `brush teeth - 3 min`, `get dressed - 6 min`, and so on. I know there are many apps "ADHD planner" apps that do this (in theory) but none of them work well IMO (too complex and/or inflexible).
+  - title: Unified notification inbox
+    emoji: "🔔"
+    description: |
+      An app where you see all of your notifications from all the services you're using together: Notion, GitHub, LinkedIn, etc. Hard to pull off because the service needs to make that info available via an API or something (Notion for example does not). Email has taken on this role of unified notification inbox but I don't want a permanent paper trail of all of my notifications, nor do I want them in the same place as my 1:1 correspondence.
 ---
 
 Do you wanna work on any of these? (Or something similar, or another thing you think I'd be into that's not listed here?) → [Contact me](/en/contact)!


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds a new idea to the `/ideas` page:

**Unified notification inbox** — an app that gathers notifications from all the services you use (Notion, GitHub, LinkedIn, etc.) in one place, without turning email into a permanent paper trail mixed in with 1:1 correspondence.

The main constraint noted is that each service needs to expose this data (e.g. via API); Notion currently does not.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-16e2a0dd-f022-4e62-9ea9-c11fe5b52296?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-16e2a0dd-f022-4e62-9ea9-c11fe5b52296&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

